### PR TITLE
Change base endpoint and generate identifier on POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Releases prior to 2.2.6 are only documented on
+Releases up to 2.2.5 are only documented on
 the [GitHub Release Page](https://github.com/rwth-acis/las2peer-FileService/releases)
 
 ## [Unreleased]
+
+### Breaking Changes
+
+- POST now longer accepts an identifier but instead generates a UUID for each upload. If the identifier should to be set
+  by the client, it is recommended to use PUT instead [#8](https://github.com/rwth-acis/las2peer-FileService/pull/8).
+- Endpoint changes ([#8](https://github.com/rwth-acis/las2peer-FileService/pull/8)):
+    - The whole services now registers as `files` and no longer as `fileservice`
+    - The previous `files` endpoints have been moved to top level.
+    - The implication of this change is that uploads directed at `/fileservice/files` now have to be sent to `/files`
+      instead.
 
 ### Changed
 

--- a/file_service/src/main/java/i5/las2peer/services/fileService/FileService.java
+++ b/file_service/src/main/java/i5/las2peer/services/fileService/FileService.java
@@ -43,10 +43,10 @@ import java.util.logging.Level;
  * This is an example service to store files in the las2peer network. One can upload and download files using the
  * service also via the WebConnector.
  */
-@ServicePath("/fileservice")
+@ServicePath("/files")
 public class FileService extends RESTService {
 
-    public static final String API_VERSION = "1.0";
+    public static final String API_VERSION = "2.0";
 
     // non HTTP standard headers
     public static final String HEADER_OWNERID = "ownerid";
@@ -64,7 +64,7 @@ public class FileService extends RESTService {
     private static final L2pLogger logger = L2pLogger.getInstance(FileService.class.getName());
     private static final String ENVELOPE_BASENAME = "file-";
     private static final SimpleDateFormat RFC2822FMT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z (zzz)");
-    private static final String RESOURCE_FILES_BASENAME = "/files";
+    private static final String RESOURCE_FILES_BASENAME = "/";
     private static final String RESOURCE_DOWNLOAD_BASENAME = "/download";
     private static final String INDEX_IDENTIFIER_PREFIX = "index-";
     private static final String RESOURCE_INDEX_JSON = "/index.json";
@@ -549,9 +549,8 @@ public class FileService extends RESTService {
 
         /**
          * This method uploads a file to the las2peer network.
+         * form/request element.
          *
-         * @param identifier        Value of the {@value i5.las2peer.services.fileService.FileService#UPLOAD_IDENTIFIER}-tagged
-         *                          form/request element.
          * @param fileContentHeader The header of the submitted file used to determine the filename.
          * @param bodyPart          The body part of the submitted file used to determine the mime type.
          * @param fileContent       The actual submitted file content.
@@ -566,27 +565,24 @@ public class FileService extends RESTService {
         @Produces(MediaType.TEXT_PLAIN)
         @ApiResponses(
                 value = {@ApiResponse(
-                        code = HttpURLConnection.HTTP_OK,
-                        message = "File upload successfull"),
-                        @ApiResponse(
-                                code = HttpURLConnection.HTTP_CREATED,
-                                message = "File successfully created"),
+                        code = HttpURLConnection.HTTP_CREATED,
+                        message = "File successfully created. Returns identifier.",
+                        response = String.class),
                         @ApiResponse(
                                 code = HttpURLConnection.HTTP_BAD_REQUEST,
                                 message = "File upload failed!"),
                         @ApiResponse(
                                 code = HttpURLConnection.HTTP_INTERNAL_ERROR,
                                 message = "File upload failed!")})
-        public Response postFile(@FormDataParam(UPLOAD_IDENTIFIER) String identifier,
-                                 @FormDataParam(UPLOAD_FILE) FormDataContentDisposition fileContentHeader,
+        public Response postFile(@FormDataParam(UPLOAD_FILE) FormDataContentDisposition fileContentHeader,
                                  @FormDataParam(UPLOAD_FILE) FormDataBodyPart bodyPart,
                                  @FormDataParam(UPLOAD_FILE) InputStream fileContent,
                                  @FormDataParam(UPLOAD_SHARE_WITH_GROUP) String shareWithGroup,
                                  @FormDataParam(UPLOAD_DESCRIPTION) String description,
                                  @FormDataParam(UPLOAD_EXCLUDE_FROM_INDEX) String excludeFromIndex) {
             FileService service = (FileService) Context.getCurrent().getService();
-            return service.uploadFile(identifier, fileContentHeader, bodyPart, fileContent, shareWithGroup, description,
-                    excludeFromIndex, false);
+            UUID uuid = UUID.randomUUID();
+            return service.uploadFile(uuid.toString(), fileContentHeader, bodyPart, fileContent, shareWithGroup, description, excludeFromIndex, false);
         }
 
         /**
@@ -608,11 +604,8 @@ public class FileService extends RESTService {
         @Produces(MediaType.TEXT_PLAIN)
         @ApiResponses(
                 value = {@ApiResponse(
-                        code = HttpURLConnection.HTTP_OK,
-                        message = "File upload successfull"),
-                        @ApiResponse(
-                                code = HttpURLConnection.HTTP_CREATED,
-                                message = "File successfully created"),
+                        code = HttpURLConnection.HTTP_CREATED,
+                        message = "File successfully created"),
                         @ApiResponse(
                                 code = HttpURLConnection.HTTP_BAD_REQUEST,
                                 message = "File upload failed!"),

--- a/frontend-examples/simple-form.html
+++ b/frontend-examples/simple-form.html
@@ -1,25 +1,22 @@
 <!-- This form only uses plain HTML and may be integrated in your website to upload files to a las2peer network using FileService -->
-<form method="post" enctype="multipart/form-data" action="http://localhost:14580/fileservice/files">
-  <div>
-    <p>Select a file from your file system to upload.</p>
-    <label for="id_filecontent">File input</label>
-    <input type="file" id="id_filecontent" name="filecontent">
-  </div>
-  <div>
-    <label for="id_identifier">Identifier (optional)</label>
-    <input type="text" id="id_identifier" name="identifier" placeholder="must be unique">
-  </div>
-  <div>
-    <label for="id_sharewithgroup">Share with group</label>
-    <input type="text" id="id_sharewithgroup" name="sharewithgroup" placeholder="enter group id">
-  </div>
-  <div>
-    <label for="id_excludefromindex">Exclude file from index listing</label>
-    <input type="checkbox" id="id_excludefromindex" name="excludefromindex">
-  </div>
-  <div>
-    <label for="id_description">Description</label>
-    <textarea id="id_description" name="description" rows="3"></textarea>
-  </div>
-  <button type="submit">Press</button> to upload the file!
+<form action="http://localhost:14580/files" enctype="multipart/form-data" method="post">
+    <div>
+        <p>Select a file from your file system to upload.</p>
+        <label for="id_filecontent">File input</label>
+        <input id="id_filecontent" name="filecontent" type="file">
+    </div>
+    <div>
+        <label for="id_sharewithgroup">Share with group</label>
+        <input id="id_sharewithgroup" name="sharewithgroup" placeholder="enter group id" type="text">
+    </div>
+    <div>
+        <label for="id_excludefromindex">Exclude file from index listing</label>
+        <input id="id_excludefromindex" name="excludefromindex" type="checkbox">
+    </div>
+    <div>
+        <label for="id_description">Description</label>
+        <textarea id="id_description" name="description" rows="3"></textarea>
+    </div>
+    <button type="submit">Press</button>
+    to upload the file!
 </form>

--- a/frontend-examples/upload.sh
+++ b/frontend-examples/upload.sh
@@ -5,7 +5,7 @@
 WEBCONNECTOR_URL=http://localhost:14580
 
 function curlcmd {
-  curl --form "filecontent=@$1;filename=$1" --form identifier=fileservice/$1 ${WEBCONNECTOR_URL}/fileservice/files
+  curl --form "filecontent=@$1;filename=$1" --form identifier=files/$1 ${WEBCONNECTOR_URL}/files
   echo "" # just for the newline character
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 java.version=14
 core.version=1.1.1
-service.version=2.2.6
+service.version=3.0.0
 service.name=i5.las2peer.services.fileService
 service.class=FileService


### PR DESCRIPTION
This is a breaking change.

As lined out in the changelog:

- POST now longer accepts an identifier but instead generates a UUID for each upload. This is intended to differentiate behaviour of POST and PUT. Clients which rely on the old behaviour should use PUT.

- Endpoint changes (Closes https://github.com/rwth-acis/RequirementsBazaar/issues/110)  
    - The whole services now registers as `files` and no longer as `fileservice`    
    - The previous `files` endpoints have been moved to top level.
    - The implication of this change is that uploads directed at `/fileservice/files` now have to be sent to `/files` instead.
